### PR TITLE
docs: add EXAMPLE_USAGE.md with validator fee verification guide

### DIFF
--- a/EXAMPLE_USAGE.md
+++ b/EXAMPLE_USAGE.md
@@ -1,0 +1,30 @@
+# Example Usage
+
+This example shows how to verify validator fees and block rewards.
+
+---
+
+## Step 1. Locate your validator pubkey
+Each CSV file contains a column `pubkey` with the validator's public key.  
+Search for your own validator pubkey in the file.
+
+---
+
+## Step 2. Find block rewards
+From the file `block_rewards_data.csv`:
+- `block_rewards`: total rewards for the validator in the given epoch.  
+- Example: `block_rewards = 1000`.
+
+---
+
+## Step 3. Apply fee formula
+The DoubleZero fee is defined as:
+doublezero_fee = block_rewards * 0.05
+```For the example above:```
+doublezero_fee = 1000 * 0.05 = 50
+
+---
+## Step 4. Cross-check with `earnings_epochXYZ.csv`
+In the `earnings_epochXYZ.csv` file:  
+- Look for your `pubkey`.  
+- Compare the column `doublezero_fee` with the calculated value.


### PR DESCRIPTION
### What changed?
- Added a new file `EXAMPLE_USAGE.md`
- Provided a step-by-step example to verify validator fees (5% of block rewards)

### Why this change?
- Makes it easier for validators to check their commission
- Improves documentation clarity

### How was it tested?
- Example walkthrough created manually and verified for consistency